### PR TITLE
debug for empty list error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .venv
 /archive/
+vlmgrpo/patches/__pycache__/unsloth_patch.cpython-310.pyc
+vlmgrpo/patches/__pycache__/__init__.cpython-310.pyc
+vlmgrpo/__pycache__/trainer.cpython-310.pyc
+vlmgrpo/__pycache__/__init__.cpython-310.pyc
+test_fix.py

--- a/vlmgrpo/trainer.py
+++ b/vlmgrpo/trainer.py
@@ -162,6 +162,7 @@ class VLMGRPOTrainer(GRPOTrainer):
                 if generation_batch["image_grid_thw"].size(0) != target_batch_size:
                     if self.grad_verbose:
                         print(f"[DEBUG] Корректировка image_grid_thw: исходный размер {generation_batch['image_grid_thw'].size(0)}, целевой размер {target_batch_size}")
+                        print(f"[DEBUG] image_grid_thw ДО корректировки: {generation_batch['image_grid_thw']}")
                     
                     # Если размерности не совпадают, корректируем image_grid_thw
                     if generation_batch["image_grid_thw"].size(0) == original_pixel_values_batch_size:
@@ -195,9 +196,13 @@ class VLMGRPOTrainer(GRPOTrainer):
                 
                     if self.grad_verbose:
                         print(f"[DEBUG] Результат корректировки: image_grid_thw размер {generation_batch['image_grid_thw'].size(0)}")
+                        print(f"[DEBUG] image_grid_thw ПОСЛЕ корректировки: {generation_batch['image_grid_thw']}")
                 else:
                     if self.grad_verbose:
                         print(f"[DEBUG] Корректировка image_grid_thw не требуется: размеры совпадают ({target_batch_size})")
+                        print(f"[DEBUG] image_grid_thw содержимое: {generation_batch['image_grid_thw']}")
+                        print(f"[DEBUG] pixel_values размер: {generation_batch['pixel_values'].shape}")
+                        print(f"[DEBUG] prompt_ids размер: {generation_batch['prompt_ids'].shape}")
                 
                 generation_batch = shuffle_tensor_dict(generation_batch)
                 self._buffered_inputs = split_tensor_dict(generation_batch, self.steps_per_generation)


### PR DESCRIPTION
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
[<ipython-input-9-cae16b5ab040>](https://localhost:8080/#) in <cell line: 0>()
     39     grad_verbose=True
     40 )
---> 41 trainer.train()

24 frames
[/usr/local/lib/python3.11/dist-packages/transformers/trainer.py](https://localhost:8080/#) in train(self, resume_from_checkpoint, trial, ignore_keys_for_eval, **kwargs)
   2239                 hf_hub_utils.enable_progress_bars()
   2240         else:
-> 2241             return inner_training_loop(
   2242                 args=args,
   2243                 resume_from_checkpoint=resume_from_checkpoint,

/usr/local/lib/python3.11/dist-packages/unsloth_zoo/compiler.py in _fast_inner_training_loop(self, batch_size, args, resume_from_checkpoint, trial, ignore_keys_for_eval)

[/content/VLM_GRPO/vlmgrpo/trainer.py](https://localhost:8080/#) in training_step(self, model, inputs, num_items_in_batch)
    407 
    408     def training_step(self, model, inputs, num_items_in_batch=None) -> torch.Tensor:
--> 409         loss=super().training_step(model,inputs,num_items_in_batch)
    410 
    411         grad_params = [p for p in model.parameters() if p.grad is not None]

/usr/local/lib/python3.11/dist-packages/unsloth/models/_utils.py in _unsloth_training_step(self, model, inputs, num_items_in_batch)

[/content/VLM_GRPO/vlmgrpo/trainer.py](https://localhost:8080/#) in compute_loss(self, model, inputs, return_outputs, num_items_in_batch)
    373                 else:
    374                     with self.accelerator.unwrap_model(self.model).disable_adapter():
--> 375                         ref_per_token_logps = self._get_per_token_logps(
    376                             self.model, input_ids, attention_mask,pixel_values, image_grid_thw,logits_to_keep
    377                         )

[/content/VLM_GRPO/vlmgrpo/trainer.py](https://localhost:8080/#) in _get_per_token_logps(self, model, input_ids, attention_mask, pixel_values, image_grid_thw, logits_to_keep)
    330         """
    331         # We add 1 to `logits_to_keep` because the last logits of the sequence is later excluded
--> 332         logits = model(input_ids=input_ids, attention_mask=attention_mask, pixel_values=pixel_values, 
    333                       image_grid_thw=image_grid_thw, logits_to_keep=logits_to_keep + 1).logits
    334         logits = logits[:, :-1, :]  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred

[/usr/local/lib/python3.11/dist-packages/torch/nn/modules/module.py](https://localhost:8080/#) in _wrapped_call_impl(self, *args, **kwargs)
   1737             return self._compiled_call_impl(*args, **kwargs)  # type: ignore[misc]
   1738         else:
-> 1739             return self._call_impl(*args, **kwargs)
   1740 
   1741     # torchrec tests the code consistency with the following code

[/usr/local/lib/python3.11/dist-packages/torch/nn/modules/module.py](https://localhost:8080/#) in _call_impl(self, *args, **kwargs)
   1748                 or _global_backward_pre_hooks or _global_backward_hooks
   1749                 or _global_forward_hooks or _global_forward_pre_hooks):
-> 1750             return forward_call(*args, **kwargs)
   1751 
   1752         result = None

[/usr/local/lib/python3.11/dist-packages/accelerate/utils/operations.py](https://localhost:8080/#) in forward(*args, **kwargs)
    816 
    817     def forward(*args, **kwargs):
--> 818         return model_forward(*args, **kwargs)
    819 
    820     # To act like a decorator so that it can be popped when doing `extract_model_from_parallel`

[/usr/local/lib/python3.11/dist-packages/accelerate/utils/operations.py](https://localhost:8080/#) in __call__(self, *args, **kwargs)
    804 
    805     def __call__(self, *args, **kwargs):
--> 806         return convert_to_fp32(self.model_forward(*args, **kwargs))
    807 
    808     def __getstate__(self):

[/usr/local/lib/python3.11/dist-packages/torch/amp/autocast_mode.py](https://localhost:8080/#) in decorate_autocast(*args, **kwargs)
     42     def decorate_autocast(*args, **kwargs):
     43         with autocast_instance:
---> 44             return func(*args, **kwargs)
     45 
     46     decorate_autocast.__script_unsupported = "@autocast() decorator is not supported in script mode"  # type: ignore[attr-defined]

[/usr/local/lib/python3.11/dist-packages/accelerate/utils/operations.py](https://localhost:8080/#) in forward(*args, **kwargs)
    816 
    817     def forward(*args, **kwargs):
--> 818         return model_forward(*args, **kwargs)
    819 
    820     # To act like a decorator so that it can be popped when doing `extract_model_from_parallel`

[/usr/local/lib/python3.11/dist-packages/accelerate/utils/operations.py](https://localhost:8080/#) in __call__(self, *args, **kwargs)
    804 
    805     def __call__(self, *args, **kwargs):
--> 806         return convert_to_fp32(self.model_forward(*args, **kwargs))
    807 
    808     def __getstate__(self):

[/usr/local/lib/python3.11/dist-packages/torch/amp/autocast_mode.py](https://localhost:8080/#) in decorate_autocast(*args, **kwargs)
     42     def decorate_autocast(*args, **kwargs):
     43         with autocast_instance:
---> 44             return func(*args, **kwargs)
     45 
     46     decorate_autocast.__script_unsupported = "@autocast() decorator is not supported in script mode"  # type: ignore[attr-defined]

[/usr/local/lib/python3.11/dist-packages/peft/peft_model.py](https://localhost:8080/#) in forward(self, input_ids, attention_mask, inputs_embeds, labels, output_attentions, output_hidden_states, return_dict, task_ids, **kwargs)
   1755             with self._enable_peft_forward_hooks(**kwargs):
   1756                 kwargs = {k: v for k, v in kwargs.items() if k not in self.special_peft_forward_args}
-> 1757                 return self.base_model(
   1758                     input_ids=input_ids,
   1759                     attention_mask=attention_mask,

[/usr/local/lib/python3.11/dist-packages/torch/nn/modules/module.py](https://localhost:8080/#) in _wrapped_call_impl(self, *args, **kwargs)
   1737             return self._compiled_call_impl(*args, **kwargs)  # type: ignore[misc]
   1738         else:
-> 1739             return self._call_impl(*args, **kwargs)
   1740 
   1741     # torchrec tests the code consistency with the following code

[/usr/local/lib/python3.11/dist-packages/torch/nn/modules/module.py](https://localhost:8080/#) in _call_impl(self, *args, **kwargs)
   1843 
   1844         try:
-> 1845             return inner()
   1846         except Exception:
   1847             # run always called hooks if they have not already been run

[/usr/local/lib/python3.11/dist-packages/torch/nn/modules/module.py](https://localhost:8080/#) in inner()
   1791                 args = bw_hook.setup_input_hook(args)
   1792 
-> 1793             result = forward_call(*args, **kwargs)
   1794             if _global_forward_hooks or self._forward_hooks:
   1795                 for hook_id, hook in (

[/usr/local/lib/python3.11/dist-packages/peft/tuners/tuners_utils.py](https://localhost:8080/#) in forward(self, *args, **kwargs)
    191 
    192     def forward(self, *args: Any, **kwargs: Any):
--> 193         return self.model.forward(*args, **kwargs)
    194 
    195     def _pre_injection_hook(self, model: nn.Module, config: PeftConfig, adapter_name: str) -> None:

[/content/unsloth_compiled_cache/unsloth_compiled_module_qwen2_5_vl.py](https://localhost:8080/#) in forward(self, input_ids, attention_mask, position_ids, past_key_values, inputs_embeds, labels, use_cache, output_attentions, output_hidden_states, return_dict, pixel_values, pixel_values_videos, image_grid_thw, video_grid_thw, rope_deltas, cache_position, second_per_grid_ts, **loss_kwargs)
   1385         second_per_grid_ts: Optional[torch.Tensor] = None,**loss_kwargs,
   1386     ) -> Union[Tuple, Qwen2_5_VLCausalLMOutputWithPast]:
-> 1387         return Qwen2_5_VLForConditionalGeneration_forward(self, input_ids, attention_mask, position_ids, past_key_values, inputs_embeds, labels, use_cache, output_attentions, output_hidden_states, return_dict, pixel_values, pixel_values_videos, image_grid_thw, video_grid_thw, rope_deltas, cache_position, second_per_grid_ts, **loss_kwargs)
   1388 
   1389     def prepare_inputs_for_generation(

[/content/unsloth_compiled_cache/unsloth_compiled_module_qwen2_5_vl.py](https://localhost:8080/#) in Qwen2_5_VLForConditionalGeneration_forward(self, input_ids, attention_mask, position_ids, past_key_values, inputs_embeds, labels, use_cache, output_attentions, output_hidden_states, return_dict, pixel_values, pixel_values_videos, image_grid_thw, video_grid_thw, rope_deltas, cache_position, second_per_grid_ts, **loss_kwargs)
    942         if pixel_values is not None:
    943             pixel_values = pixel_values.type(self.visual.dtype)
--> 944             image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
    945             n_image_tokens = (input_ids == self.config.image_token_id).sum().item()
    946             n_image_features = image_embeds.shape[0]

[/usr/local/lib/python3.11/dist-packages/torch/nn/modules/module.py](https://localhost:8080/#) in _wrapped_call_impl(self, *args, **kwargs)
   1737             return self._compiled_call_impl(*args, **kwargs)  # type: ignore[misc]
   1738         else:
-> 1739             return self._call_impl(*args, **kwargs)
   1740 
   1741     # torchrec tests the code consistency with the following code

[/usr/local/lib/python3.11/dist-packages/torch/nn/modules/module.py](https://localhost:8080/#) in _call_impl(self, *args, **kwargs)
   1748                 or _global_backward_pre_hooks or _global_backward_hooks
   1749                 or _global_forward_hooks or _global_forward_pre_hooks):
-> 1750             return forward_call(*args, **kwargs)
   1751 
   1752         result = None

[/usr/local/lib/python3.11/dist-packages/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py](https://localhost:8080/#) in forward(self, hidden_states, grid_thw)
    517         """
    518         hidden_states = self.patch_embed(hidden_states)
--> 519         rotary_pos_emb = self.rot_pos_emb(grid_thw)
    520         window_index, cu_window_seqlens = self.get_window_index(grid_thw)
    521         cu_window_seqlens = torch.tensor(

[/usr/local/lib/python3.11/dist-packages/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py](https://localhost:8080/#) in rot_pos_emb(self, grid_thw)
    458             wpos_ids = wpos_ids.flatten()
    459             pos_ids.append(torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1))
--> 460         pos_ids = torch.cat(pos_ids, dim=0)
    461         max_grid_size = grid_thw[:, 1:].max()
    462         rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size)

RuntimeError: torch.cat(): expected a non-empty list of Tensors